### PR TITLE
Fix #64 Support for i18n parameters

### DIFF
--- a/src/notification.js
+++ b/src/notification.js
@@ -181,9 +181,9 @@ export class Notification {
   log(message, options = {}, defaults = this.__config.defaults) {
     if (this.translate(options, defaults)) {
       if (message instanceof Array) {
-        message = message.map(item => this.i18n.tr(item));
+        message = message.map(item => this.i18n.tr(item, options.i18n || {}));
       } else {
-        message = this.__i18n.tr(message);
+        message = this.__i18n.tr(message, options.i18n || {});
       }
     }
 

--- a/test/notification.spec.js
+++ b/test/notification.spec.js
@@ -85,5 +85,23 @@ describe('Notification', () => {
         }, 50);
       });
     });
+
+    it('Should show translated notification with options and i18n params', function (done) {
+      let container = new Container();
+      let config = container.get(Config).configure();
+      let notification = container.get(Notification);
+      let randomText = Math.random().toString();
+
+      component.create(bootstrap).then(function () {
+        notification.note('originalWithVariable', {addnCls: 'test', timeout: 10, i18n: {variable: randomText}});
+
+        setTimeout(() => {
+          expect(notification.__humane.el.className).toMatch(/test/);
+          expect(notification.__humane.el.innerHTML).toBe(`translated with ${randomText}`);
+          expect(notification.__humane.currentMsg.timeout).toBe(10);
+          done();
+        }, 50);
+      });
+    });
   });
 });

--- a/test/resources/de/test.json
+++ b/test/resources/de/test.json
@@ -1,1 +1,4 @@
-{"original" : "translated"}
+{
+  "original": "translated",
+  "originalWithVariable": "translated with {{variable}}"
+}


### PR DESCRIPTION
I decided to use a `tParams` map container to avoid namespace conflict with humane-js options.

Example usage would be:

```
translation.json
{
  "say hello to": "Hello, {{name}}!"
};

app.js
this.notification.log("say hello to", {tParams: {name: "World"}});
```