### PR TITLE
fix(notification): notification constructor preserves explicitly specified container element.

### DIFF
--- a/src/notification.js
+++ b/src/notification.js
@@ -93,13 +93,17 @@ export class Notification {
     }
 
     // ensure humane.container is document.body after 'aurelia-composed'
-    this.setContainer();
-    let aureliaComposedListener = () => {
+    if (!humane.container) {
       this.setContainer();
-      DOM.removeEventListener('aurelia-composed', aureliaComposedListener);
-    };
+      let aureliaComposedListener = () => {
+        if (!humane.container) {
+          this.setContainer();
+        }
+        DOM.removeEventListener('aurelia-composed', aureliaComposedListener);
+      };
 
-    DOM.addEventListener('aurelia-composed', aureliaComposedListener);
+      DOM.addEventListener('aurelia-composed', aureliaComposedListener);
+    }
   }
 
   /**

--- a/test/notification.spec.js
+++ b/test/notification.spec.js
@@ -66,6 +66,32 @@ describe('Notification', () => {
         done();
       });
     });
+
+    it('Should preserve a custom container element.', function(done) {
+      let container = new Container();
+      let config = container.get(Config).configure();
+      let humane = container.get(Humane);
+      let containerDiv = humane.container = DOM.createElement('div');
+      let notification = container.get(Notification);
+
+      component.create(bootstrap).then( function() {
+        let i18n = container.get(I18N);
+
+        expect(notification.__i18n).toBe(i18n);
+        expect(notification.__config).toBe(config);
+        expect(notification.__humane).toBe(humane);
+        expect(notification.__humane.container).toBe(containerDiv);
+        expect(notification.__humane.baseCls).toBe('humane');
+        expect(notification.__humane.el.outerHTML).toBe('<div style="display: none;"></div>');
+
+        for (let key in config.notifications) {
+          expect(notification[key]).toBeDefined();
+          expect(typeof notification[key]).toBe('function');
+        }
+
+        done();
+      });
+    });
   });
 
   describe('.note()', function() {


### PR DESCRIPTION
If the injected Humane object has already been configured with a container, or setContainer is called before the 'aurelia-composed' event is fired there is no reason to override this with the body element.

I have a custom dependency injection resolver that handles setting the container for Notification instances and it also handles inserting that container into the DOM when 'aurelia-composed' fires, so the existing behavior of aurelia-notification is completely foiling my efforts, and I believe it is unnecessary. In the default case where no container is specified, setting it to the body by default is still the right thing to do, and this change preserves that.